### PR TITLE
Fixed Bug With Some Skin Names Short Circuiting Early

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -78,7 +78,7 @@ function getConvertedNicknameToName(message: string): string {
 function getIncludedName(message: string, names: Array<string>): string {
   let nameIncluded = '';
   names.some((name: string) => {
-    if (message.includes(name)) {
+    if (message.includes(` ${name}`)) {
       nameIncluded = name;
     }
     return nameIncluded;


### PR DESCRIPTION
Skin name searches would sometimes return the wrong result, for example, a search for "Prestige" skins might return the results of "iG" skins.
Fixed.