### PR TITLE
Allow Users to Search for Prestige Skins by Name

### DIFF
--- a/features/skins.ts
+++ b/features/skins.ts
@@ -1,7 +1,7 @@
 import { MessageEmbed } from 'discord.js';
 import { Embed, Skin } from '../modules/constants';
 import { makeChampionSkinAPICall } from '../modules/api';
-import { formatPrestigeSkinNames, normalizeChampionName } from '../modules/cleanup';
+import { normalizeChampionName } from '../modules/cleanup';
 import { skinToChampionMap } from '../modules/init';
 import { constructEmbedMessage } from '../modules/messages/normalMessageGeneration';
 import { constructErrorMessage, getRandomElementFromArray } from '../modules/messages/errorMessageGeneration';
@@ -69,14 +69,13 @@ function makeChampionSkinMessageEmbed(championName: string, skinData: Skin): Mes
 }
 
 function makeSkinMessageEmbed(skinData: Skin, skinName: string): MessageEmbed {
-  skinName = formatPrestigeSkinNames(skinName.toLowerCase());
   const { name, splashPath, tilePath } = skinData;
   let messageObject: Embed = {
     title: `Skin Line: ${name}`,
     thumbnail: tilePath,
     image: splashPath,
     fields: [{
-      name: 'Champions with this skin line:',
+      name: 'Champions Within This Skin Line:',
       value: skinToChampionMap.get(skinName)!.join(', '),
     }]
   }

--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ import { getChampionSkin, getSkin } from './features/skins';
 import { constructEmbedMessage } from './modules/messages/normalMessageGeneration';
 import { championNames, chromaNames, init, skinNames } from './modules/init';
 import { normalizeChampionName } from './modules/cleanup';
+import { constructErrorMessage } from './modules/messages/errorMessageGeneration';
 const championNickNames: Array<string> = ['mundo', 'nunu', 'jarvan', 'j4', 'kogmaw', 'reksai', 'tf', 'asol', 'yi', 
                                           'akechi', 'mord', 'rhaast', 'powder', 'best boy', 'best girl', 'violet', 
                                           'cait', 'cupcake', 'ez'];
@@ -48,7 +49,7 @@ function sendProperMessageResponse(message: Message)  {
 
   const nickname = getConvertedNicknameToName(content);
   if (nickname) {
-    content += ' ' + nickname;
+    content += ` ${nickname}`;
   }
 
   const championName = getIncludedName(content, championNames);
@@ -66,6 +67,9 @@ function sendProperMessageResponse(message: Message)  {
   }
   else if (skinName) {
     return sendSkinData(skinName, message);
+  }
+  else {
+    return sendErrorMessage(message);
   }
 }
 
@@ -136,6 +140,10 @@ function sendChampionSkinChromaData(championName: string, skinName: string, chro
     .catch((err) => {
       return console.error('when getting the embedded message for champion data', err)
     });
+}
+
+function sendErrorMessage(message: Message): Promise<Message> {
+  return message.reply(constructErrorMessage('Not Found', 'Your message did not match any of our queries, or did not contain any known key words.'));
 }
 
 function sendHelpMessage(): MessageEmbed {

--- a/modules/api.ts
+++ b/modules/api.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { region, basePath, Chroma, Skin } from '../modules/constants';
 import { capitalizeWordsInString, normalizeChampionNameForAPI } from './cleanup';
-import { skinToChampionMap } from './init';
 import { constructErrorMessage } from './messages/errorMessageGeneration';
 
 export async function makeChampionAPICall(championName: string): Promise<any> {

--- a/modules/cleanup.ts
+++ b/modules/cleanup.ts
@@ -96,10 +96,3 @@ export function normalizeNameString(name: string): string {
   
   return name;
 }
-
-export function formatPrestigeSkinNames(skinName: string): string {
-  if (skinName.includes('prestige')) {
-    return 'prestige';
-  }
-  return skinName;
-}

--- a/modules/init.ts
+++ b/modules/init.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
 import { region, basePath, Chroma, Skin } from '../modules/constants';
-import { formatPrestigeSkinNames } from './cleanup';
 
 export let championNames: Array<string> = [];
-export let skinNames: Array<string> = [];
+export let skinNames: Array<string> = ['prestige'];
 export let chromaNames: Array<string> = [];
 export let skinToChampionMap: Map<string, Array<string>> = new Map();
+skinToChampionMap.set('prestige', [])
 
 export function init() {
   setChampionNamesAndSkinNamesAndChromaNames();
@@ -30,12 +30,17 @@ function addToChampionNames(championName: string) {
 
 function addChampionsToSkinMap(championName: string, skinArray: Array<Skin>) {
   skinArray.forEach(({ name: skinName }: { name: string }) => {
-    if (skinName !== 'Original') {
-      skinName = formatPrestigeSkinNames(skinName.toLowerCase());
+    skinName = skinName.toLowerCase();
+    
+    if (skinName !== 'original') {
+      const isPrestige = skinName.includes('prestige');
+
+      if (isPrestige) {
+        setNewItemToSkinMap(championName, 'prestige');
+      }
+
       if (skinToChampionMap.has(skinName)) {
-        let skinArray = skinToChampionMap.get(skinName)!;
-        pushNewItemToArray(championName, skinArray);
-        skinToChampionMap.set(skinName, skinArray);
+        setNewItemToSkinMap(championName, skinName);
       } else {
         skinToChampionMap.set(skinName, [championName]);
       }
@@ -70,4 +75,10 @@ function pushNewItemToArray(item: string, array: Array<string>) {
   }
 
   array.push(item);
+}
+
+function setNewItemToSkinMap(championName: string, skinName: string) {
+  let skinArray = skinToChampionMap.get(skinName)!;
+  pushNewItemToArray(championName, skinArray);
+  skinToChampionMap.set(skinName, skinArray);
 }


### PR DESCRIPTION
Prestige skins have specific names for each one, making them individual instead of just on the "Prestige" line.
I wanted Prestige skins to be searchable by just "Prestige" but also by their full nonsense name.
This change allows that.