### PR TITLE
Added elder drake command for LoL item details

### DIFF
--- a/features/items.ts
+++ b/features/items.ts
@@ -6,26 +6,26 @@ import { constructErrorMessage } from '../modules/messages/errorMessageGeneratio
 import { normalizeItemName, normalizeStatName,  } from '../modules/cleanup';
 import { itemMap } from '../modules/init';
 
-//Gets item ID from name
+// Gets item ID from name
 export function getItemID(itemName: string): any {
     const normalizedItemName: string = normalizeItemName(itemName);
     return itemMap.get(normalizedItemName);
 } 
 
-//Item API call
+// Item API call
 export async function makeItemAPICall(itemName: string): Promise<any> {
     const itemID = getItemID(itemName);
     return await axios.get(`${basePath}/${region}/items/${itemID}.json`)
-      .then((resp) => {
-        return resp.data;
+      .then((res) => {
+        return res.data;
       });
   }
 
-//Gets item and sends message to Discord
-export async function getItem(itemName: string): Promise<any> {
+// Gets item and sends message to Discord
+export async function fetchItem(itemName: string): Promise<any> {
     return await makeItemAPICall(itemName)
-        .then((data) => {
-            return constructItemEmbedMessage(data);
+        .then((res) => {
+            return constructItemEmbedMessage(res);
         })
         .catch((err) => {
             return constructErrorMessage('Having trouble getting that item\'s info!', 'Are you sure you spelled their name correctly? If so, the API might be down. Try again in a little while.');
@@ -33,34 +33,46 @@ export async function getItem(itemName: string): Promise<any> {
 }
 
 export function constructItemEmbedMessage(itemData: any) {
-    const { name, id, tier, icon, simpleDescription, shop } = itemData;
+    const { name, id, tier, icon, simpleDescription, passives, stats, shop} = itemData;
     const itemMessage = new MessageEmbed()
         .setColor('#87E4E9')
         .setAuthor('The elder drake speaks...', 'https://cdn.discordapp.com/attachments/651148711115882556/877567670608871494/elder-icon.png')
         .setTitle(name)
         .setThumbnail(icon)
-        .setDescription(`${simpleDescription} \nItem ID: ${id}`)  
-        for (var passive in itemData.passives) {
-            if (itemData.passives[passive]) {
-                if (itemData.passives[passive].name !== 'Mythic') {
-                    itemMessage.addFields({ name: itemData.passives[passive].name, value: itemData.passives[passive].effects})
-                }
+
+        if (simpleDescription) {
+            itemMessage.setDescription(`${simpleDescription} \nItem ID: ${id}`);
+        } else {
+            itemMessage.setDescription(`Item ID: ${id}`);
+        };
+
+        Object.entries(passives).forEach((passive: any): void => {
+            const [passiveName, passiveValues] = passive;
+            if (passiveValues.mythic) {
+                itemMessage.addFields({ name: 'Mythic', value: 'No data. To be implemented at a later date', inline: false })
+                itemMessage.setTitle(`${name} (Mythic)`)
+            } else if (passiveValues.unique) {
+                itemMessage.addFields({ name: 'UNIQUE Passive', value: passiveValues.effects, inline: false })
+            } else {
+                itemMessage.addFields({ name: 'Passive', value: passiveValues.effects, inline: false })
             }
-        }
-        for (var stat in itemData.stats) {
-            if (itemData.stats[stat].flat > 0) {
-                itemMessage.addFields({ name: normalizeStatName(stat), value: itemData.stats[stat].flat, inline: false})
+        })
+
+        Object.entries(stats).forEach((itemStat: any): void => {
+            const [statName, statValue] = itemStat;
+            if (statValue.flat > 0) {
+                itemMessage.addFields({ name: normalizeStatName(statName), value: statValue.flat, inline: false });
             }
-        }
-        for (var price in itemData.shop.prices) {
-            if (itemData.shop.prices[price] > 0) {
-                if(price === 'total') {
-                    itemMessage.addFields({ name: 'Buy', value: itemData.shop.prices[price], inline: true})
-                } else {
-                    itemMessage.addFields({ name: capitalizeWordsInString(price), value: itemData.shop.prices[price], inline: true})    
-                }
+        });
+
+        Object.entries(shop.prices).forEach((price: any): void => {
+            const [shopType, shopValue] = price;
+            if (shopType === 'total') {
+                itemMessage.addFields({ name: 'Buy', value: shopValue, inline: true})
+            } else if (shopValue > 0) {
+                itemMessage.addFields({ name: capitalizeWordsInString(shopType), value: shopValue, inline: true})    
             }
-        }
-    console.log(itemMessage);
+        });
+
     return itemMessage;
 }

--- a/features/items.ts
+++ b/features/items.ts
@@ -22,7 +22,7 @@ export async function makeItemAPICall(itemName: string): Promise<any> {
   }
 
 // Gets item and sends message to Discord
-export async function fetchItem(itemName: string): Promise<any> {
+export async function getItem(itemName: string): Promise<any> {
     return await makeItemAPICall(itemName)
         .then((res) => {
             return constructItemEmbedMessage(res);

--- a/features/items.ts
+++ b/features/items.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import { MessageEmbed } from 'discord.js';
+import { region, basePath } from '../modules/constants';
+import { capitalizeWordsInString } from '../modules/cleanup';
+import { constructErrorMessage } from '../modules/messages/errorMessageGeneration';
+import { normalizeItemName, normalizeStatName,  } from '../modules/cleanup';
+import { itemMap } from '../modules/init';
+
+//Gets item ID from name
+export function getItemID(itemName: string): any {
+    const normalizedItemName: string = normalizeItemName(itemName);
+    return itemMap.get(normalizedItemName);
+} 
+
+//Item API call
+export async function makeItemAPICall(itemName: string): Promise<any> {
+    const itemID = getItemID(itemName);
+    return await axios.get(`${basePath}/${region}/items/${itemID}.json`)
+      .then((resp) => {
+        return resp.data;
+      });
+  }
+
+//Gets item and sends message to Discord
+export async function getItem(itemName: string): Promise<any> {
+    return await makeItemAPICall(itemName)
+        .then((data) => {
+            return constructItemEmbedMessage(data);
+        })
+        .catch((err) => {
+            return constructErrorMessage('Having trouble getting that item\'s info!', 'Are you sure you spelled their name correctly? If so, the API might be down. Try again in a little while.');
+        })
+}
+
+export function constructItemEmbedMessage(itemData: any) {
+    const { name, id, tier, icon, simpleDescription, shop } = itemData;
+    const itemMessage = new MessageEmbed()
+        .setColor('#87E4E9')
+        .setAuthor('The elder drake speaks...', 'https://cdn.discordapp.com/attachments/651148711115882556/877567670608871494/elder-icon.png')
+        .setTitle(name)
+        .setThumbnail(icon)
+        .setDescription(`${simpleDescription} \nItem ID: ${id}`)  
+        for (var passive in itemData.passives) {
+            if (itemData.passives[passive]) {
+                if (itemData.passives[passive].name !== 'Mythic') {
+                    itemMessage.addFields({ name: itemData.passives[passive].name, value: itemData.passives[passive].effects})
+                }
+            }
+        }
+        for (var stat in itemData.stats) {
+            if (itemData.stats[stat].flat > 0) {
+                itemMessage.addFields({ name: normalizeStatName(stat), value: itemData.stats[stat].flat, inline: false})
+            }
+        }
+        for (var price in itemData.shop.prices) {
+            if (itemData.shop.prices[price] > 0) {
+                if(price === 'total') {
+                    itemMessage.addFields({ name: 'Buy', value: itemData.shop.prices[price], inline: true})
+                } else {
+                    itemMessage.addFields({ name: capitalizeWordsInString(price), value: itemData.shop.prices[price], inline: true})    
+                }
+            }
+        }
+    console.log(itemMessage);
+    return itemMessage;
+}

--- a/main.ts
+++ b/main.ts
@@ -91,7 +91,7 @@ function getConvertedNicknameToName(message: string): string {
   return normalizeChampionName(nickname).toLowerCase();
 }
 
-function getIncludedName(message: string, names: Array<string>): string {
+function getIncludedName(message: string, names: Array<string>): string { 
   let nameIncluded = '';
   names.some((name: string) => {
     if (message.includes(` ${name}`)) {

--- a/main.ts
+++ b/main.ts
@@ -2,7 +2,7 @@ import { Client, Message, MessageAdditions, MessageEmbed, MessageOptions } from 
 import { prefix } from './modules/constants';
 import { getChampion } from './features/champions';
 import { getChampionSkin, getSkin } from './features/skins';
-import { getItem } from './features/items';
+import { fetchItem } from './features/items';
 import { constructEmbedMessage } from './modules/messages/normalMessageGeneration';
 import { championNames, chromaNames, init, skinNames, itemNames } from './modules/init';
 import { normalizeChampionName } from './modules/cleanup';
@@ -107,11 +107,11 @@ function sendChampionData(championName: string, message: Message): Promise<void 
     .then((embed: MessageEmbed) => {
       return message.reply(embed)
         .catch((err) => {
-          return console.error('when sending embedded message for champion data', err);
+          return console.error('When sending embedded message for champion data', err);
         });
     })
     .catch((err) => {
-      return console.error('when getting the embedded message for champion data', err)
+      return console.error('When getting the embedded message for champion data', err)
     });
 }
 
@@ -120,11 +120,11 @@ function sendSkinData(skinName: string, message: Message): Promise<void | Messag
     .then((embed: MessageEmbed) => {
       return message.reply(embed)
       .catch((err) => {
-        return console.error('when sending embedded message for skin data', err);
+        return console.error('When sending embedded message for skin data', err);
       });
     })
     .catch((err) => {
-      return console.error('when getting the embedded message for skin data', err)
+      return console.error('When getting the embedded message for skin data', err)
     });
 }
 
@@ -133,11 +133,11 @@ function sendChampionSkinData(championName: string, skinName: string, message: M
   .then((embed: MessageEmbed) => {
     return message.reply(embed)
       .catch((err) => {
-        return console.error('when sending embedded message for champion data', err);
+        return console.error('When sending embedded message for champion data', err);
       });
   })
     .catch((err) => {
-      return console.error('when getting the embedded message for champion data', err)
+      return console.error('When getting the embedded message for champion data', err)
     });
 }
 
@@ -146,24 +146,24 @@ function sendChampionSkinChromaData(championName: string, skinName: string, chro
   .then((embed: MessageEmbed) => {
     return message.reply(embed)
       .catch((err) => {
-        return console.error('when sending embedded message for champion data', err);
+        return console.error('When sending embedded message for champion data', err);
       });
   })
     .catch((err) => {
-      return console.error('when getting the embedded message for champion data', err)
+      return console.error('When getting the embedded message for champion data', err)
     });
 }
 
 function sendItemData(itemName: string, message: Message): Promise<void | Message> {
-  return getItem(itemName)
+  return fetchItem(itemName)
     .then((embed: MessageEmbed) => {
       return message.reply(embed)
         .catch((err) => {
-          return console.error('when sending embedded message for item data', err);
+          return console.error('When sending embedded message for item data', err);
         });
     })
     .catch((err) => {
-      return console.error('when getting the embedded message for item data', err)
+      return console.error('When getting the embedded message for item data', err)
     });
 }
 
@@ -187,7 +187,11 @@ function sendHelpMessage(): MessageEmbed {
       Returns the specified champion's ability information, including any details or notes by the developers.
 
       - !elder *[skin name]* *[champion name]*
-      Returns a list of all of the released skins for the specified champion.`
+      Returns a list of all of the released skins for the specified champion.
+      
+      - !elder *[item name]* 
+      Returns the general item info such as including description, passives, stats, and shop price.`
+
     }],
     url: 'https://github.com/myumi/elder-drake'
   });

--- a/main.ts
+++ b/main.ts
@@ -2,10 +2,13 @@ import { Client, Message, MessageAdditions, MessageEmbed, MessageOptions } from 
 import { prefix } from './modules/constants';
 import { getChampion } from './features/champions';
 import { getChampionSkin, getSkin } from './features/skins';
+import { getItem } from './features/items';
 import { constructEmbedMessage } from './modules/messages/normalMessageGeneration';
-import { championNames, chromaNames, init, skinNames } from './modules/init';
+import { championNames, chromaNames, init, skinNames, itemNames } from './modules/init';
 import { normalizeChampionName } from './modules/cleanup';
 import { constructErrorMessage } from './modules/messages/errorMessageGeneration';
+import { normalizeItemName } from './modules/cleanup';
+
 const championNickNames: Array<string> = ['mundo', 'nunu', 'jarvan', 'j4', 'kogmaw', 'reksai', 'tf', 'asol', 'yi', 
                                           'akechi', 'mord', 'rhaast', 'powder', 'best boy', 'best girl', 'violet', 
                                           'cait', 'cupcake', 'ez'];
@@ -52,9 +55,15 @@ function sendProperMessageResponse(message: Message)  {
     content += ` ${nickname}`;
   }
 
+  const itemNickname = normalizeItemName(content);
+  if (itemNickname) {
+    content += ` ${itemNickname}`;
+  }
+
   const championName = getIncludedName(content, championNames);
   const skinName = getIncludedName(content, skinNames);
   const chromaName = getIncludedName(content, chromaNames);
+  const itemName = getIncludedName(content, itemNames)
 
   if (chromaName && skinName && championName) {
     return sendChampionSkinChromaData(championName, skinName, chromaName, message);
@@ -67,6 +76,9 @@ function sendProperMessageResponse(message: Message)  {
   }
   else if (skinName) {
     return sendSkinData(skinName, message);
+  }
+  else if (itemName) {
+    return sendItemData(itemName, message);
   }
   else {
     return sendErrorMessage(message);
@@ -139,6 +151,19 @@ function sendChampionSkinChromaData(championName: string, skinName: string, chro
   })
     .catch((err) => {
       return console.error('when getting the embedded message for champion data', err)
+    });
+}
+
+function sendItemData(itemName: string, message: Message): Promise<void | Message> {
+  return getItem(itemName)
+    .then((embed: MessageEmbed) => {
+      return message.reply(embed)
+        .catch((err) => {
+          return console.error('when sending embedded message for item data', err);
+        });
+    })
+    .catch((err) => {
+      return console.error('when getting the embedded message for item data', err)
     });
 }
 

--- a/main.ts
+++ b/main.ts
@@ -162,7 +162,7 @@ function sendItemData(itemName: string, message: Message): Promise<void | Messag
           return console.error('when sending embedded message for item data', err);
         });
     })
-    .catch((err) => {
+    .catch((err: Error) => {
       return console.error('when getting the embedded message for item data', err)
     });
 }

--- a/main.ts
+++ b/main.ts
@@ -2,7 +2,7 @@ import { Client, Message, MessageAdditions, MessageEmbed, MessageOptions } from 
 import { prefix } from './modules/constants';
 import { getChampion } from './features/champions';
 import { getChampionSkin, getSkin } from './features/skins';
-import { fetchItem } from './features/items';
+import { getItem } from './features/items';
 import { constructEmbedMessage } from './modules/messages/normalMessageGeneration';
 import { championNames, chromaNames, init, skinNames, itemNames } from './modules/init';
 import { normalizeChampionName } from './modules/cleanup';
@@ -150,20 +150,20 @@ function sendChampionSkinChromaData(championName: string, skinName: string, chro
       });
   })
     .catch((err) => {
-      return console.error('When getting the embedded message for champion data', err)
+      return console.error('when getting the embedded message for champion data', err)
     });
 }
 
 function sendItemData(itemName: string, message: Message): Promise<void | Message> {
-  return fetchItem(itemName)
+  return getItem(itemName)
     .then((embed: MessageEmbed) => {
       return message.reply(embed)
         .catch((err) => {
-          return console.error('When sending embedded message for item data', err);
+          return console.error('when sending embedded message for item data', err);
         });
     })
     .catch((err) => {
-      return console.error('When getting the embedded message for item data', err)
+      return console.error('when getting the embedded message for item data', err)
     });
 }
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { Client, Message, MessageAdditions, MessageEmbed, MessageOptions } from 'discord.js';
+import { Client, Message, MessageEmbed } from 'discord.js';
 import { prefix } from './modules/constants';
 import { getChampion } from './features/champions';
 import { getChampionSkin, getSkin } from './features/skins';

--- a/modules/cleanup.ts
+++ b/modules/cleanup.ts
@@ -96,3 +96,62 @@ export function normalizeNameString(name: string): string {
   
   return name;
 }
+
+//Simplify any name by lowercasing and removing apostrophes
+export function simplifyName(itemName: string) {
+  let simpleItemName = itemName.toLowerCase();
+  return simpleItemName.replace(/'/,'');
+}
+
+//Normalize Stat name for printing
+export function normalizeStatName(statName: string): string {
+  let normalizedStat = statName.split(/(?=[A-Z])/).join(" ");
+  normalizedStat = (capitalizeWordsInString(normalizedStat));
+  return normalizedStat;
+}
+
+// Normalize item name based on input
+export function normalizeItemName(itemName: string): string {
+  itemName = simplifyName(itemName);
+  const nicknames: any = {
+      'seal': 'Dark Seal',
+      'red jungle': 'Emberknife',
+      'blue jungle': 'Hailblade',
+      'tear': 'Tear of the Goddess',
+      'red ward': 'Control Ward',
+      'blue trinket': 'Farsight Alteration',
+      'farsight trinket': 'Farsight Alteration',
+      'red trinket': 'Oracle Lens',
+      'yellow trinket': 'Stealth Ward',
+      'sweeper': 'Oracle Lens',
+      'sweeping lens': 'Oracle Lens',
+      'herald': 'Eye of the Herald',
+      'dematerializer': 'Minion Dematerializer',
+      'magic boots': 'Slightly Magical Boots',
+      'buscuit': 'Total Biscuit of Everlasting Will',
+      'swifties': 'Boots of Swiftness',
+      'lucidity boots': 'Ionian Boots of Lucidity',
+      'boots of lucidity': 'Ionian Boots of Lucidity',
+      'merc treads': 'Mercurys Treads',
+      'mercury treads': 'Mercurys Treads',
+      'boots5': 'Mobility Boots',
+      'mobi boots': 'Mobility Boots',
+      'steelcaps': 'Plated Steelcaps',
+      'sorc treads': 'Sorcerers Treads',
+      'bf sword': 'B.F. Sword',
+      'agility cloak': 'Cloak of Agility',
+      'large rod': 'Needelessly Large Rod',
+      'magic mantle': 'Null-Magic Mantle',
+      'aegis': 'Aegis of the Legion',
+      'cinder': 'Bamis Cinder'
+
+          //TO BE CONTINUED
+
+    }
+
+    if (nicknames.hasOwnProperty(itemName)) {
+      return simplifyName(nicknames[itemName]);
+    }
+  
+    return itemName;
+}

--- a/modules/cleanup.ts
+++ b/modules/cleanup.ts
@@ -97,13 +97,13 @@ export function normalizeNameString(name: string): string {
   return name;
 }
 
-//Simplify any name by lowercasing and removing apostrophes
+// Simplify any name by lowercasing and removing apostrophes
 export function simplifyName(itemName: string) {
   let simpleItemName = itemName.toLowerCase();
   return simpleItemName.replace(/'/,'');
 }
 
-//Normalize Stat name for printing
+// Normalize stat name for printing
 export function normalizeStatName(statName: string): string {
   let normalizedStat = statName.split(/(?=[A-Z])/).join(" ");
   normalizedStat = (capitalizeWordsInString(normalizedStat));

--- a/modules/init.ts
+++ b/modules/init.ts
@@ -7,7 +7,7 @@ export let championNames: Array<string> = [];
 export let skinNames: Array<string> = ['prestige'];
 export let chromaNames: Array<string> = [];
 export let skinToChampionMap: Map<string, Array<string>> = new Map();
-skinToChampionMap.set('prestige', [])
+// skinToChampionMap.set('prestige', [])
 
 export function init() {
   setChampionNamesAndSkinNamesAndChromaNames();
@@ -47,13 +47,13 @@ function addToChampionNames(championName: string) {
 function addChampionsToSkinMap(championName: string, skinArray: Array<Skin>) {
   skinArray.forEach(({ name: skinName }: { name: string }) => {
     skinName = skinName.toLowerCase();
-    
-    if (skinName !== 'original') {
-      const isPrestige = skinName.includes('prestige');
 
-      if (isPrestige) {
-        setNewItemToSkinMap(championName, 'prestige');
-      }
+    if (skinName !== 'original') {
+      // const isPrestige = skinName.includes('prestige');
+
+      // if (isPrestige) {
+      //   setNewItemToSkinMap(championName, 'prestige');
+      // }
 
       if (skinToChampionMap.has(skinName)) {
         setNewItemToSkinMap(championName, skinName);

--- a/modules/init.ts
+++ b/modules/init.ts
@@ -11,6 +11,7 @@ skinToChampionMap.set('prestige', [])
 
 export function init() {
   setChampionNamesAndSkinNamesAndChromaNames();
+  setItemNames();
 }
 
 async function setChampionNamesAndSkinNamesAndChromaNames() {

--- a/modules/init.ts
+++ b/modules/init.ts
@@ -26,12 +26,12 @@ async function setChampionNamesAndSkinNamesAndChromaNames() {
     });
 }
 
-//Sets item map for getting item ID from item name. Should be included in init() in init.ts
+// Sets item map for getting item ID from item name.
 export async function setItemNames() {
   await axios.get(`${basePath}/${region}/items.json`)
-      .then(resp => {
-          for (var id in resp.data) {
-              let itemName = simplifyName(resp.data[id].name.replace(/'/,''));
+      .then(res => {
+          for (let id in res.data) {
+              let itemName = simplifyName(res.data[id].name.replace(/'/,''));
               itemMap.set(itemName, id);
               itemNames.push(itemName);
           }

--- a/modules/init.ts
+++ b/modules/init.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { region, basePath, Chroma, Skin } from '../modules/constants';
-
+import { simplifyName } from './cleanup';
+export let itemMap = new Map<string, string>();
+export let itemNames: Array<string> = [];
 export let championNames: Array<string> = [];
 export let skinNames: Array<string> = ['prestige'];
 export let chromaNames: Array<string> = [];
@@ -21,6 +23,19 @@ async function setChampionNamesAndSkinNamesAndChromaNames() {
         addToChromaNames(data[champion].skins);
       });
     });
+}
+
+//Sets item map for getting item ID from item name. Should be included in init() in init.ts
+export async function setItemNames() {
+  await axios.get(`${basePath}/${region}/items.json`)
+      .then(resp => {
+          for (var id in resp.data) {
+              let itemName = simplifyName(resp.data[id].name.replace(/'/,''));
+              itemMap.set(itemName, id);
+              itemNames.push(itemName);
+          }
+      }
+  )
 }
 
 function addToChampionNames(championName: string) {


### PR DESCRIPTION
Added new item feature to bot that allows a user to input an item and retrieve its details: Name, Description, Passives, Buy and Sell Cost, and Stats.

The command accepted is: `!elder [item]`

New functions:
 - Initial function at bot start up now gathers a list of items and ids for later requests. 
 - Added cleanup functions `simplifyName`(simplifies item name to all lowercase and no apostrophes), `normalizeStatName`(cleans up stat names returned by API), and `normalizeItemName`(if a user inputs a nickname for an item within the list of nicknames, this will return the appropriate name to be used by the API).
 - New items file within features that contains functions to convert user input (item) to the appropriate item ID, perform an API call with the ID, and construct a message containing all relevant details of the items.
 - Added new `else statement` within `main.ts` for passing an [item] value to the bot, as well as a function to initialize an API call and return appropriate information if the value entered is an item.

New functions make use of the following URLs:
- http://cdn.merakianalytics.com/riot/lol/resources/latest/en-US/items.json
- http://cdn.merakianalytics.com/riot/lol/resources/latest/en-US/items/